### PR TITLE
Fix test and passing of map of parameters

### DIFF
--- a/src/main/java/org/jboss/pnc/buildkitchen/model/Artifact.java
+++ b/src/main/java/org/jboss/pnc/buildkitchen/model/Artifact.java
@@ -57,7 +57,7 @@ public class Artifact extends PanacheEntity {
     public static Map<PurlSha, Artifact> findByPurls(Set<PurlSha> purls) {
         List<PurlSha> purlShas = new ArrayList<>(purls);
         String query = "FROM Artifact a WHERE ";
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         for (int i = 0; i< purlShas.size(); i++){
             if(i > 0) {
                 query += " OR ";
@@ -69,7 +69,6 @@ public class Artifact extends PanacheEntity {
             params.put(purlKey, purlSha.purl());
             params.put(shaKey, purlSha.sha256());
         }
-
 
         return find(query, params).<Artifact>stream()
                 .collect(Collectors.toMap(Artifact::getPurlSha, Function.identity()));

--- a/src/test/java/org/jboss/pnc/buildkitchen/RecipesResourceTest.java
+++ b/src/test/java/org/jboss/pnc/buildkitchen/RecipesResourceTest.java
@@ -78,8 +78,8 @@ public class RecipesResourceTest {
                 .buildTools(Set.of(BuildToolDTO.builder().identifier("JAVA").version("11").build()))
                 .image("pnc-image-java11")
                 .memory(2 * 1024 * 1024 * 1023)
-                .builtArtifacts(Set.of(new ArtifactDTO("pkg:maven/junit/junit@1.2.3.redhat-00001"),
-                        new ArtifactDTO("pkg:maven/junit/junit-runner@1.2.3.redhat-00001")))
+                .builtArtifacts(Set.of(new ArtifactDTO("pkg:maven/junit/junit@1.2.3.redhat-00001", "123456789012345678901234567890ab"),
+                        new ArtifactDTO("pkg:maven/junit/junit-runner@1.2.3.redhat-00001", "123456789012345678901234567890cd")))
                 .versionGenerated("1.2.3.redhat-00001")
                 .build();
 


### PR DESCRIPTION
The find(String query, Map<String, Object> params) method expects map of Objects, not Strings. It uses the find(String query, Object... params) method instead, which was wrong.